### PR TITLE
Fix bug with empty attribute removal

### DIFF
--- a/lib/modules/emptyAttrs.js
+++ b/lib/modules/emptyAttrs.js
@@ -2,11 +2,16 @@
 const removeAttrs = ['id', 'class', 'style', 'title', 'lang', 'dir', 'onclick', 'ondblclick', 'onmousedown', 'onmouseup', 'onmouseover', 'onmousemove', 'onmouseout', 'onkeypress', 'onkeydown', 'onkeyup']
 
 module.exports = (node) => {
+  // If the node has no attributes, nothing to do
   if (!node.attrs) return node
+  // Check each attribute in the node
   for (let attr in node.attrs) {
+    // Check if attribute is on the delete list (removeAttrs)
     if (removeAttrs.indexOf(attr) > -1) {
+      // Check each attribute node. If they're ALL empty, delete the whole node
+      // If one has content, leave everything
       const val = node.attrs[attr]
-      if (val.length < 1 || val[0].content.match(/^\s*$/)) {
+      if (val.every(checkVal => checkVal.content.match(/^\s*$/))) {
         delete node.attrs[attr]
       }
     }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "cssnano": "^3.7.4",
     "indx": "^0.2.3",
+    "reshape-expressions": "^0.1.4",
     "reshape-plugin-util": "^0.2.1",
     "svgo": "^0.7.0",
     "uglify-js": "^2.7.3"

--- a/test/fixtures/expressions_in_tags.expected.html
+++ b/test/fixtures/expressions_in_tags.expected.html
@@ -1,0 +1,1 @@
+<div id="thisIsId" class="thisIsClass">thisIsContent</div>

--- a/test/fixtures/expressions_in_tags.html
+++ b/test/fixtures/expressions_in_tags.html
@@ -1,0 +1,1 @@
+<div id='{{ testId }}' class='{{ testClass }}'>{{ testContent }}</div>

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ const reshape = require('reshape')
 const {readFileSync} = require('fs')
 const test = require('ava')
 const fixtures = path.join(__dirname, 'fixtures')
+const exp = require('reshape-expressions')
 
 test('aggressively collapses whitespace', (t) => {
   return compare(t, 'whitespace_aggressive', { aggressiveCollapse: true })
@@ -23,15 +24,16 @@ test('minifies svg', (t) => compare(t, 'svg'))
 test('removes redundant attributes', (t) => compare(t, 'redundant_attr'))
 test('removes comments', (t) => compare(t, 'comments'))
 test('handles custom tags', (t) => compare(t, 'custom_tag'))
+test('handles expressions in tags', (t) => compare(t, 'expressions_in_tags'))
 
 function compare (t, name, opts, log) {
   const input = readFileSync(path.join(fixtures, `${name}.html`), 'utf8')
   const expected = readFileSync(path.join(fixtures, `${name}.expected.html`), 'utf8')
 
-  return reshape({ plugins: minify(opts) })
+  return reshape({ plugins: [ exp(), minify(opts) ] })
     .process(input)
-    .tap((res) => log && console.log(res.output()))
+    .tap((res) => log && console.log(res.output({ testId: 'thisIsId', testClass: 'thisIsClass', testContent: 'thisIsContent' })))
     .then((res) => {
-      t.is(res.output().trim(), expected.trim())
+      t.is(res.output({ testId: 'thisIsId', testClass: 'thisIsClass', testContent: 'thisIsContent' }).trim(), expected.trim())
     })
 }


### PR DESCRIPTION
Only the first value in an attribute was checked for being empty. Caused issue with expressions being removed as empty attributes. Fixed by iterating through each node in attribute and only removing if all are empty.